### PR TITLE
chore: add preview script + nvm postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && vite build --ssr",
-    "preview": "vite preview",
-    "test": "svelte-kit sync && vitest run"
+    "preview": "vite preview --base=/coke-mouse",
+    "test": "svelte-kit sync && vitest run",
+    "postinstall": "bash -lc 'nvm use' || true"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.4",


### PR DESCRIPTION
## Summary
- configure preview to serve from /coke-mouse base path
- run `nvm use` via bash postinstall to respect `.nvmrc`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25940c1f88322b4db94caf308ea31