### PR TITLE
feat: add positive habits with export v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Coke-mouse is a habit management system that gamifies the balance between positi
 
 ## Features
 
-- **Habit Tracking** 📊: Log and track time spent on various positive habits.
-- **Point System** 🏆: Earn points based on the completion of positive habits.
-- **Rewards** 🎁: Spend points on selected 'negative' habits as a form of reward.
-- **Dynamic Point Valuation** 📉: Over time, the point value can change, encouraging better habit management.
+- **Negative Habits** 📉: Track time between indulgences and stretch goals as you improve.
+- **Positive Habits** 📈: Create daily habits and log successes with free-form notes and timestamps.
+- **Export/Import** 🔄: Save or load all habit data as JSON for backup or transfer.
 
 ## Technology
 
@@ -29,6 +28,19 @@ npm run build
 ## Persistence & Export/Import
 
 State is saved in IndexedDB using [localforage](https://github.com/localForage/localForage). Use the **Export JSON** button to download your habits and **Import JSON** to restore them from a file.
+
+Export files are versioned. The current format is `version: 2` and includes both negative and positive sections:
+
+```json
+{
+  "version": 2,
+  "exportedAt": 0,
+  "negative": { "habits": [], "logs": [] },
+  "positive": { "habits": [], "logs": [] }
+}
+```
+
+Older `version: 1` exports contained only the negative section and can still be imported.
 
 ## Contributing
 

--- a/src/lib/exportImport.ts
+++ b/src/lib/exportImport.ts
@@ -1,0 +1,59 @@
+import { get } from 'svelte/store';
+import { habits, logs, validate as validateNegative } from './store';
+import { positive, type PositiveHabit, type PositiveHabitLog } from './positive';
+import type { Habit, Log } from './types';
+
+export interface ExportPayloadV2 {
+  version: 2;
+  exportedAt: number;
+  negative: {
+    habits: Habit[];
+    logs: Log[];
+  };
+  positive: {
+    habits: PositiveHabit[];
+    logs: PositiveHabitLog[];
+  };
+}
+
+export function exportAll(): ExportPayloadV2 {
+  const pos = get(positive);
+  return {
+    version: 2,
+    exportedAt: Date.now(),
+    negative: { habits: get(habits), logs: get(logs) },
+    positive: { habits: Object.values(pos.habits), logs: Object.values(pos.logs) }
+  };
+}
+
+function validatePositive(data: any): data is { habits: PositiveHabit[]; logs: PositiveHabitLog[] } {
+  if (typeof data !== 'object' || data === null) return false;
+  if (!Array.isArray(data.habits) || !Array.isArray(data.logs)) return false;
+  const habitsOk = data.habits.every(
+    (h: any) => typeof h.id === 'string' && typeof h.name === 'string' && typeof h.createdAt === 'number'
+  );
+  const logsOk = data.logs.every(
+    (l: any) =>
+      typeof l.id === 'string' &&
+      typeof l.habitId === 'string' &&
+      typeof l.ts === 'number' &&
+      typeof l.note === 'string'
+  );
+  return habitsOk && logsOk;
+}
+
+export function importAll(data: any): boolean {
+  if (typeof data !== 'object' || data === null) return false;
+  if (data.version === 2) {
+    if (!validateNegative(data.negative) || !validatePositive(data.positive)) return false;
+    habits.replace(data.negative);
+    positive.replace({ habits: data.positive.habits, logs: data.positive.logs });
+    return true;
+  }
+  if (data.version === 1) {
+    if (!validateNegative(data)) return false;
+    habits.replace(data);
+    return true;
+  }
+  return false;
+}

--- a/src/lib/positive.ts
+++ b/src/lib/positive.ts
@@ -1,0 +1,110 @@
+import { writable, get } from 'svelte/store';
+import { v4 as uuid } from 'uuid';
+import { load, save } from './persist';
+import { browser } from '$app/environment';
+
+export type PositiveHabitId = string;
+
+export interface PositiveHabit {
+  id: PositiveHabitId;
+  name: string;
+  createdAt: number;
+}
+
+export interface PositiveHabitLog {
+  id: string;
+  habitId: PositiveHabitId;
+  ts: number;
+  note: string;
+}
+
+export interface PositiveState {
+  habits: Record<PositiveHabitId, PositiveHabit>;
+  logs: Record<string, PositiveHabitLog>;
+  habitLogIndex: Record<PositiveHabitId, string[]>;
+  version: 1;
+}
+
+const KEY = 'cokemouse.positive.state.v1';
+
+const emptyState: PositiveState = { habits: {}, logs: {}, habitLogIndex: {}, version: 1 };
+
+const store = writable<PositiveState>(emptyState);
+
+if (browser) {
+  load<PositiveState>(KEY).then(d => {
+    if (d && d.version === 1) {
+      store.set({
+        habits: d.habits ?? {},
+        logs: d.logs ?? {},
+        habitLogIndex: d.habitLogIndex ?? {},
+        version: 1
+      });
+    }
+  });
+}
+
+let t: any;
+function scheduleSave() {
+  if (!browser) return;
+  clearTimeout(t);
+  t = setTimeout(() => save(get(store), KEY), 200);
+}
+
+function buildIndex(logs: PositiveHabitLog[]): Record<PositiveHabitId, string[]> {
+  const idx: Record<PositiveHabitId, string[]> = {};
+  logs
+    .sort((a, b) => b.ts - a.ts)
+    .forEach(l => {
+      idx[l.habitId] = idx[l.habitId] ? [...idx[l.habitId], l.id] : [l.id];
+    });
+  return idx;
+}
+
+export const positive = {
+  subscribe: store.subscribe,
+  add(name: string) {
+    const id = uuid();
+    store.update(s => {
+      s.habits[id] = { id, name, createdAt: Date.now() };
+      s.habitLogIndex[id] = s.habitLogIndex[id] ?? [];
+      return s;
+    });
+    scheduleSave();
+  },
+  rename(id: string, name: string) {
+    store.update(s => {
+      if (s.habits[id]) s.habits[id].name = name;
+      return s;
+    });
+    scheduleSave();
+  },
+  log(habitId: string, note: string) {
+    const id = uuid();
+    const entry: PositiveHabitLog = { id, habitId, ts: Date.now(), note };
+    store.update(s => {
+      s.logs[id] = entry;
+      const arr = s.habitLogIndex[habitId] ?? [];
+      arr.unshift(id);
+      s.habitLogIndex[habitId] = arr;
+      return s;
+    });
+    scheduleSave();
+  },
+  getLogs(habitId: string): PositiveHabitLog[] {
+    const state = get(store);
+    const ids = state.habitLogIndex[habitId] ?? [];
+    return ids.map(i => state.logs[i]);
+  },
+  replace(data: { habits: PositiveHabit[]; logs: PositiveHabitLog[] }) {
+    const habitMap: Record<string, PositiveHabit> = {};
+    data.habits.forEach(h => (habitMap[h.id] = h));
+    const logMap: Record<string, PositiveHabitLog> = {};
+    data.logs.forEach(l => (logMap[l.id] = l));
+    const index = buildIndex(data.logs);
+    store.set({ habits: habitMap, logs: logMap, habitLogIndex: index, version: 1 });
+    scheduleSave();
+  }
+};
+
+export { emptyState as positiveEmptyState };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
-import { habits, logs, formatDuration, validate } from '../lib/store';
-import { get } from 'svelte/store';
+import { habits, formatDuration } from '../lib/store';
+import { positive } from '../lib/positive';
+import { exportAll, importAll } from '../lib/exportImport';
 import type { Habit } from '../lib/types';
+import { browser } from '$app/environment';
 
+let tab: 'positive' | 'negative' = 'negative';
+if (browser) {
+  const saved = localStorage.getItem('cm:lastTab');
+  if (saved === 'positive' || saved === 'negative') tab = saved;
+}
+function switchTab(t: 'positive' | 'negative') {
+  tab = t;
+  if (browser) localStorage.setItem('cm:lastTab', t);
+}
+
+// negative vars
 let name = '';
 let editing: Habit | null = null;
 let goalHours = 0;
@@ -38,8 +51,57 @@ function resetStreak(id: string) {
   habits.resetStreak(id);
 }
 
+function sinceLast(h: Habit): string {
+  if (!h.lastLoggedAt) return '—';
+  const elapsed = (Date.now() - new Date(h.lastLoggedAt).getTime()) / 1000;
+  return formatDuration(elapsed);
+}
+
+function elapsed(h: Habit): number {
+  if (!h.lastLoggedAt) return 0;
+  const e = (Date.now() - new Date(h.lastLoggedAt).getTime()) / 1000;
+  return Math.min(e, h.goalSeconds);
+}
+
+// positive vars
+let pName = '';
+let logDialog: HTMLDialogElement;
+let logging: { id: string; name: string } | null = null;
+let note = '';
+const show: Record<string, boolean> = {};
+
+function addPositive() {
+  if (pName.trim()) {
+    positive.add(pName.trim());
+    pName = '';
+  }
+}
+
+function openLog(h: { id: string; name: string }) {
+  logging = h;
+  logDialog.showModal();
+}
+
+function saveLog() {
+  if (logging) positive.log(logging.id, note.trim());
+  note = '';
+  logDialog.close();
+  logging = null;
+}
+
+function cancelLog() {
+  note = '';
+  logDialog.close();
+  logging = null;
+}
+
+function toggleTimeline(id: string) {
+  show[id] = !show[id];
+}
+
+// export / import
 function exportJson() {
-  const data = JSON.stringify({ habits: get(habits), logs: get(logs) }, null, 2);
+  const data = JSON.stringify(exportAll(), null, 2);
   const blob = new Blob([data], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -57,25 +119,13 @@ function importJson(event: Event) {
   reader.onload = () => {
     try {
       const data = JSON.parse(reader.result as string);
-      if (validate(data)) habits.replace(data);
+      if (!importAll(data)) console.error('Invalid JSON');
     } catch (err) {
       console.error('Invalid JSON');
     }
   };
   reader.readAsText(file);
   input.value = '';
-}
-
-function sinceLast(h: Habit): string {
-  if (!h.lastLoggedAt) return '—';
-  const elapsed = (Date.now() - new Date(h.lastLoggedAt).getTime()) / 1000;
-  return formatDuration(elapsed);
-}
-
-function elapsed(h: Habit): number {
-  if (!h.lastLoggedAt) return 0;
-  const e = (Date.now() - new Date(h.lastLoggedAt).getTime()) / 1000;
-  return Math.min(e, h.goalSeconds);
 }
 </script>
 
@@ -89,32 +139,76 @@ function elapsed(h: Habit): number {
   </form>
 </dialog>
 
+<dialog bind:this={logDialog} on:close={cancelLog}>
+  <form on:submit|preventDefault={saveLog}>
+    <label>Note:
+      <textarea bind:value={note}></textarea>
+    </label>
+    <menu>
+      <button type="submit">Save</button>
+      <button type="button" on:click={cancelLog}>Cancel</button>
+    </menu>
+  </form>
+</dialog>
+
 <div class="controls">
   <button on:click={exportJson}>Export JSON</button>
   <input type="file" accept="application/json" on:change={importJson} />
 </div>
 
-<form on:submit|preventDefault={addHabit}>
-  <input bind:value={name} placeholder="New habit" />
-  <button type="submit">Add</button>
-</form>
+<div role="tablist" class="tabs">
+  <button role="tab" aria-selected={tab === 'positive'} aria-controls="positive-panel" on:click={() => switchTab('positive')}>Positive</button>
+  <button role="tab" aria-selected={tab === 'negative'} aria-controls="negative-panel" on:click={() => switchTab('negative')}>Negative</button>
+</div>
 
-{#each $habits as habit (habit.id)}
-  <div class="habit">
-    <strong>{habit.name}</strong>
-    <div>Since last: {sinceLast(habit)}</div>
-    <div>Goal: {formatDuration(habit.goalSeconds)}</div>
-    <progress max={habit.goalSeconds} value={elapsed(habit)}></progress>
-    <div>Streak: {habit.streak}</div>
-    <button on:click={() => logHabit(habit.id)}>Log</button>
-    <button on:click={() => openEdit(habit)}>Edit Goal</button>
-    <button on:click={() => resetStreak(habit.id)}>Reset Streak</button>
+{#if tab === 'positive'}
+  <div id="positive-panel" role="tabpanel">
+    <form on:submit|preventDefault={addPositive}>
+      <input bind:value={pName} placeholder="New habit" />
+      <button type="submit">Add</button>
+    </form>
+    {#each Object.values($positive.habits) as habit (habit.id)}
+      <div class="habit">
+        <strong>{habit.name}</strong>
+        <button on:click={() => openLog(habit)}>Log</button>
+        <button on:click={() => toggleTimeline(habit.id)}>{show[habit.id] ? 'Hide' : 'Show'} timeline</button>
+        {#if show[habit.id]}
+          <ul>
+            {#each positive.getLogs(habit.id) as l (l.id)}
+              <li>{new Date(l.ts).toLocaleString()}: {l.note}</li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    {/each}
   </div>
-{/each}
+{:else}
+  <div id="negative-panel" role="tabpanel">
+    <form on:submit|preventDefault={addHabit}>
+      <input bind:value={name} placeholder="New habit" />
+      <button type="submit">Add</button>
+    </form>
+
+    {#each $habits as habit (habit.id)}
+      <div class="habit">
+        <strong>{habit.name}</strong>
+        <div>Since last: {sinceLast(habit)}</div>
+        <div>Goal: {formatDuration(habit.goalSeconds)}</div>
+        <progress max={habit.goalSeconds} value={elapsed(habit)}></progress>
+        <div>Streak: {habit.streak}</div>
+        <button on:click={() => logHabit(habit.id)}>Log</button>
+        <button on:click={() => openEdit(habit)}>Edit Goal</button>
+        <button on:click={() => resetStreak(habit.id)}>Reset Streak</button>
+      </div>
+    {/each}
+  </div>
+{/if}
 
 <style>
 form { margin-bottom: 1rem; }
 .controls { margin-bottom: 1rem; }
 .habit { margin-top: 1rem; }
+.tabs { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
+[role="tab"][aria-selected="true"] { font-weight: bold; }
 progress { width: 100%; }
 </style>

--- a/test/exportImport.test.ts
+++ b/test/exportImport.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { habits } from '../src/lib/store';
+import { positive } from '../src/lib/positive';
+import { exportAll, importAll } from '../src/lib/exportImport';
+import { get } from 'svelte/store';
+
+vi.mock('../src/lib/persist', () => ({ load: async () => null, save: async () => {} }));
+
+describe('export/import', () => {
+  beforeEach(() => {
+    habits.replace({ habits: [], logs: [] });
+    positive.replace({ habits: [], logs: [] });
+  });
+
+  it('export includes positive', () => {
+    positive.add('p');
+    const data = exportAll();
+    expect(data.positive.habits.length).toBe(1);
+  });
+
+  it('import v2 replaces positive cleanly', () => {
+    positive.add('old');
+    const payload = {
+      version: 2,
+      exportedAt: 0,
+      negative: { habits: [], logs: [] },
+      positive: {
+        habits: [{ id: 'x', name: 'X', createdAt: 1 }],
+        logs: [{ id: 'l', habitId: 'x', ts: 2, note: 'n' }]
+      }
+    };
+    const ok = importAll(payload);
+    expect(ok).toBe(true);
+    const state = get(positive);
+    expect(Object.keys(state.habits)).toEqual(['x']);
+    expect(state.habitLogIndex['x'][0]).toBe('l');
+  });
+
+  it('import v1 leaves positive intact', () => {
+    positive.add('keep');
+    const before = get(positive);
+    const ok = importAll({ version: 1, habits: [], logs: [] });
+    expect(ok).toBe(true);
+    expect(get(positive)).toEqual(before);
+  });
+
+  it('bad import does not mutate state', () => {
+    positive.add('keep');
+    const before = get(positive);
+    const ok = importAll({ version: 2, negative: {}, positive: {} });
+    expect(ok).toBe(false);
+    expect(get(positive)).toEqual(before);
+  });
+});

--- a/test/positive.test.ts
+++ b/test/positive.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { positive } from '../src/lib/positive';
+import { get } from 'svelte/store';
+
+vi.mock('../src/lib/persist', () => ({ load: async () => null, save: async () => {} }));
+
+describe('positive store', () => {
+  beforeEach(() => {
+    positive.replace({ habits: [], logs: [] });
+    vi.useRealTimers();
+  });
+
+  it('initializes empty state', () => {
+    const state = get(positive);
+    expect(state).toEqual({ habits: {}, logs: {}, habitLogIndex: {}, version: 1 });
+  });
+
+  it('createHabit adds habit with name + createdAt', () => {
+    positive.add('test');
+    const state = get(positive);
+    const habit = Object.values(state.habits)[0];
+    expect(habit.name).toBe('test');
+    expect(typeof habit.createdAt).toBe('number');
+  });
+
+  it('logSuccess inserts log with epoch ms and note', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    positive.add('a');
+    const id = Object.keys(get(positive).habits)[0];
+    positive.log(id, 'done');
+    const state = get(positive);
+    const logId = state.habitLogIndex[id][0];
+    expect(state.logs[logId]).toMatchObject({ habitId: id, ts: 1000, note: 'done' });
+  });
+
+  it('timeline is newest-first', () => {
+    vi.useFakeTimers();
+    positive.add('a');
+    const id = Object.keys(get(positive).habits)[0];
+    vi.setSystemTime(0);
+    positive.log(id, 'first');
+    vi.setSystemTime(1000);
+    positive.log(id, 'second');
+    const logs = positive.getLogs(id);
+    expect(logs[0].note).toBe('second');
+    expect(logs[1].note).toBe('first');
+  });
+});


### PR DESCRIPTION
## What
- add positive habit store with success logging
- tabbed UI for positive and negative habits
- export/import JSON bumped to version 2 with positive data

## Why
- capture successful actions alongside negative habit tracking
- allow backups including new positive data

## How
- new `positive` store persisted to local storage
- tab switcher and dialogs for positive habit logging
- shared export/import utilities with validation for v1 and v2 formats

## Testing
- `npm test`
- `npm run build`
- `npm run preview` (manual)


------
https://chatgpt.com/codex/tasks/task_e_68c25e87fa208322a780d9b89a23cbe8