### PR TITLE
feat: add negative habit timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Coke-mouse is a habit management system that gamifies the balance between positi
 ## Features
 
 - **Negative Habits** 📉: Track time between indulgences and stretch goals as you improve.
+- **Negative Timelines** 🕒: View scrollable histories of negative habit logs (read-only).
 - **Positive Habits** 📈: Create daily habits and log successes with free-form notes and timestamps.
 - **Export/Import** 🔄: Save or load all habit data as JSON for backup or transfer.
 - **Delete Habits** 🗑️: Remove a habit and all its logs via a protected confirmation dialog.

--- a/src/lib/NegativeHabitItem.svelte
+++ b/src/lib/NegativeHabitItem.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { logs, formatDuration } from './store';
+  import type { Habit } from './types';
+  import NegativeTimeline from './NegativeTimeline.svelte';
+
+  export let habit: Habit;
+  export let logHabit: (id: string) => void;
+  export let openEdit: (h: Habit) => void;
+  export let resetStreak: (id: string) => void;
+  export let openDelete: (id: string, name: string) => void;
+
+  let show = false;
+  const panelId = `neg-tl-${habit.id}`;
+
+  function sinceLast(): string {
+    if (!habit.lastLoggedAt) return '—';
+    const elapsed = (Date.now() - new Date(habit.lastLoggedAt).getTime()) / 1000;
+    return formatDuration(elapsed);
+    }
+
+  function elapsed(): number {
+    if (!habit.lastLoggedAt) return 0;
+    const e = (Date.now() - new Date(habit.lastLoggedAt).getTime()) / 1000;
+    return Math.min(e, habit.goalSeconds);
+  }
+
+  $: $logs;
+  $: timeline = logs.getTimeline(habit.id);
+  $: last = timeline[0];
+</script>
+
+<div class="habit">
+  <strong>{habit.name}</strong>
+  {#if last && !show}
+    <div>Last: {new Date(last.at).toLocaleString()}</div>
+  {/if}
+  <div>Since last: {sinceLast()}</div>
+  <div>Goal: {formatDuration(habit.goalSeconds)}</div>
+  <progress max={habit.goalSeconds} value={elapsed()}></progress>
+  <div>Streak: {habit.streak}</div>
+  <button on:click={() => logHabit(habit.id)}>Log</button>
+  <button on:click={() => openEdit(habit)}>Edit Goal</button>
+  <button on:click={() => resetStreak(habit.id)}>Reset Streak</button>
+  <button on:click={() => openDelete(habit.id, habit.name)}>Delete</button>
+  <button aria-expanded={show} aria-controls={panelId} on:click={() => (show = !show)}>
+    {show ? 'Hide timeline' : 'View timeline'}
+  </button>
+  {#if show}
+    <div
+      id={panelId}
+      aria-label={`Timeline for ${habit.name}`}
+      class="timeline"
+    >
+      <NegativeTimeline logs={timeline} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .timeline {
+    max-height: 200px;
+    overflow-y: auto;
+  }
+</style>

--- a/src/lib/NegativeTimeline.svelte
+++ b/src/lib/NegativeTimeline.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { Log } from './types';
+  export let logs: Log[] = [];
+
+  function note(l: Log): string {
+    return (l as any).note ?? 'logged';
+  }
+</script>
+
+{#if logs.length === 0}
+  <p>No logs yet.</p>
+{:else}
+  <ul>
+    {#each logs as l (l.at)}
+      <li>{new Date(l.at).toLocaleString()} — {note(l)}</li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+</style>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -131,7 +131,12 @@ export const habits = {
 };
 
 export const logs = {
-  subscribe: logsStore.subscribe
+  subscribe: logsStore.subscribe,
+  getTimeline(habitId: string): Log[] {
+    return get(logsStore)
+      .filter(l => l.habitId === habitId)
+      .sort((a, b) => new Date(b.at).getTime() - new Date(a.at).getTime());
+  }
 };
 
 export function formatDuration(seconds: number): string {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@ import { exportAll, importAll } from '../lib/exportImport';
 import type { Habit } from '../lib/types';
 import { browser } from '$app/environment';
 import ConfirmDeleteHabitDialog from '../lib/ConfirmDeleteHabitDialog.svelte';
+import NegativeHabitItem from '../lib/NegativeHabitItem.svelte';
 
 let tab: 'positive' | 'negative' = 'negative';
 if (browser) {
@@ -50,18 +51,6 @@ function saveGoal() {
 
 function resetStreak(id: string) {
   habits.resetStreak(id);
-}
-
-function sinceLast(h: Habit): string {
-  if (!h.lastLoggedAt) return '—';
-  const elapsed = (Date.now() - new Date(h.lastLoggedAt).getTime()) / 1000;
-  return formatDuration(elapsed);
-}
-
-function elapsed(h: Habit): number {
-  if (!h.lastLoggedAt) return 0;
-  const e = (Date.now() - new Date(h.lastLoggedAt).getTime()) / 1000;
-  return Math.min(e, h.goalSeconds);
 }
 
 // positive vars
@@ -238,17 +227,13 @@ function importJson(event: Event) {
     </form>
 
     {#each $habits as habit (habit.id)}
-      <div class="habit">
-        <strong>{habit.name}</strong>
-        <div>Since last: {sinceLast(habit)}</div>
-        <div>Goal: {formatDuration(habit.goalSeconds)}</div>
-        <progress max={habit.goalSeconds} value={elapsed(habit)}></progress>
-        <div>Streak: {habit.streak}</div>
-        <button on:click={() => logHabit(habit.id)}>Log</button>
-        <button on:click={() => openEdit(habit)}>Edit Goal</button>
-        <button on:click={() => resetStreak(habit.id)}>Reset Streak</button>
-        <button on:click={() => openDelete('negative', habit.id, habit.name)}>Delete</button>
-      </div>
+      <NegativeHabitItem
+        {habit}
+        {logHabit}
+        {openEdit}
+        {resetStreak}
+        openDelete={(id, name) => openDelete('negative', id, name)}
+      />
     {/each}
   </div>
 {/if}
@@ -259,7 +244,6 @@ form { margin-bottom: 1rem; }
 .habit { margin-top: 1rem; }
 .tabs { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
 [role="tab"][aria-selected="true"] { font-weight: bold; }
-progress { width: 100%; }
 .toast {
   position: fixed;
   bottom: 1rem;

--- a/test/negativeTimeline.test.ts
+++ b/test/negativeTimeline.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { habits, logs } from '../src/lib/store';
+import { get } from 'svelte/store';
+
+const saveMock = vi.hoisted(() => vi.fn());
+vi.mock('../src/lib/persist', () => ({ load: async () => null, save: saveMock }));
+
+describe('negative timeline selector', () => {
+  beforeEach(() => {
+    habits.replace({ habits: [], logs: [] });
+    saveMock.mockClear();
+    vi.useFakeTimers();
+  });
+
+  it('getTimeline returns newest-first', () => {
+    habits.add('a');
+    const id = get(habits)[0].id;
+    vi.setSystemTime(0);
+    habits.log(id);
+    vi.setSystemTime(31000);
+    habits.log(id);
+    const timeline = logs.getTimeline(id);
+    expect(new Date(timeline[0].at).getTime()).toBe(31000);
+    expect(new Date(timeline[1].at).getTime()).toBe(0);
+  });
+
+  it('getTimeline handles habits with no logs', () => {
+    habits.add('a');
+    const id = get(habits)[0].id;
+    const timeline = logs.getTimeline(id);
+    expect(timeline).toEqual([]);
+  });
+});

--- a/test/negativeTimelineComponent.test.ts
+++ b/test/negativeTimelineComponent.test.ts
@@ -1,0 +1,54 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NegativeHabitItem from '../src/lib/NegativeHabitItem.svelte';
+import NegativeTimeline from '../src/lib/NegativeTimeline.svelte';
+import { habits } from '../src/lib/store';
+import { get } from 'svelte/store';
+
+const saveMock = vi.hoisted(() => vi.fn());
+vi.mock('../src/lib/persist', () => ({ load: async () => null, save: saveMock }));
+
+function noop() {}
+
+describe('Negative timeline components', () => {
+  beforeEach(() => {
+    habits.replace({ habits: [], logs: [] });
+    saveMock.mockClear();
+    vi.useFakeTimers();
+  });
+
+  it('toggle button shows timeline and updates aria attributes', async () => {
+    habits.add('a');
+    const habit = get(habits)[0];
+    habits.log(habit.id);
+    const { getByRole, queryByLabelText } = render(NegativeHabitItem, {
+      props: {
+        habit,
+        logHabit: noop,
+        openEdit: noop,
+        resetStreak: noop,
+        openDelete: noop
+      }
+    });
+    const btn = getByRole('button', { name: 'View timeline' });
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    await fireEvent.click(btn);
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(queryByLabelText(`Timeline for ${habit.name}`)).toBeTruthy();
+  });
+
+  it('NegativeTimeline shows empty state', () => {
+    const { getByText } = render(NegativeTimeline, { props: { logs: [] } });
+    getByText('No logs yet.');
+  });
+
+  it('NegativeTimeline renders timestamp and note', () => {
+    const at = new Date('2025-09-10T21:43:00Z').toISOString();
+    const note = 'oops';
+    const { getByText } = render(NegativeTimeline, {
+      props: { logs: [{ habitId: 'h', at, note } as any] }
+    });
+    const ts = new Date(at).toLocaleString();
+    getByText(`${ts} — ${note}`);
+  });
+});


### PR DESCRIPTION
## Summary
- show scrollable timelines for negative habits
- add selector for negative log timelines
- document new read-only timeline feature in README

## Testing
- `npm run test`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68c269617a9883229925fdd5dff2c106