### PR TITLE
feat(metric): Time-of-Day metric for bedtime (Positive) — Log Now/Log Time, 6PM wrap, CSV columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Export files are versioned. The current format is `version: 2` and includes both
 
 Older `version: 1` exports contained only the negative section and can still be imported.
 
+## Metrics
+
+- **Time of Day (Bedtime)**: mark a Positive habit to track nightly bedtimes.
+  - Actions: **Log Now** captures the current local time, **Log Time…** lets you enter a specific date and HH:MM.
+  - Stats: Last, Best (7d), and Tonight’s target (Last - 5m, never earlier than an hour before the wrap).
+  - Comparison uses a 6PM wrap by default so 11:00 PM outranks 2:00 AM.
+  - CSV export adds metric_kind, metric_minutes, metric_normalized, metric_display, metric_tz_offset columns.
+
 ## Contributing
 
 Interested in contributing? Great! Please read our contributing guidelines for details on our code of conduct and the process for submitting pull requests.

--- a/src/lib/PositiveTimeline.svelte
+++ b/src/lib/PositiveTimeline.svelte
@@ -73,7 +73,16 @@
     <ul>
       {#each g.logs as l (l.id)}
         <li>
-          {new Date(l.ts).toLocaleString()} — {l.note}
+          <span class="when" title={new Date(l.ts).toLocaleString()}>
+            {#if l.metric?.kind === 'timeOfDay'}
+              <span class="metric-chip">🕒 {l.metric.display}</span>
+            {:else}
+              {new Date(l.ts).toLocaleString()}
+            {/if}
+          </span>
+          {#if l.note}
+            <span class="note">— {l.note}</span>
+          {/if}
           <button aria-label="Edit log" on:click={() => openEdit(l)}>✏️</button>
           <button aria-label="Delete log" on:click={() => openDelete(l)}>🗑️</button>
         </li>
@@ -92,9 +101,22 @@
     display: flex;
     gap: 0.25rem;
     align-items: center;
+    flex-wrap: wrap;
   }
   li button {
     margin-left: 0.25rem;
+  }
+  .metric-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    background: #eef2ff;
+    border-radius: 999px;
+    padding: 0 0.4rem;
+    font-size: 0.9em;
+  }
+  .note {
+    flex: 1 1 auto;
   }
   h3 {
     margin-top: 0.5rem;

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,3 +1,6 @@
+import type { TimeOfDayMetric } from './metric';
+import { metricCsvHeader, metricCsvRow } from './csv_metric_appendix';
+
 export function escapeCsv(value: string): string {
   if (value === undefined || value === null) value = '';
   const needsQuote = /[",\n\r]/.test(value);
@@ -10,19 +13,23 @@ export interface CsvLog {
   habitId: string;
   ts: number;
   note?: string;
+  metric?: TimeOfDayMetric;
 }
 
 export function logsToCsv(logs: CsvLog[]): string {
-  const header = 'log_id,habit_id,epoch_ms,iso_utc,local_iso,note';
+  const metricHeader = metricCsvHeader().join(',');
+  const header = `log_id,habit_id,epoch_ms,iso_utc,local_iso,note,${metricHeader}`;
   const rows = logs.map(l => {
     const d = new Date(l.ts);
+    const metricRow = metricCsvRow(l.metric).map(escapeCsv);
     return [
       escapeCsv(l.id),
       escapeCsv(l.habitId),
       String(l.ts),
       escapeCsv(d.toISOString()),
       escapeCsv(d.toLocaleString()),
-      escapeCsv(l.note ?? '')
+      escapeCsv(l.note ?? ''),
+      ...metricRow
     ].join(',');
   });
   return [header, ...rows].join('\r\n') + '\r\n';

--- a/src/lib/csv_metric_appendix.ts
+++ b/src/lib/csv_metric_appendix.ts
@@ -1,0 +1,30 @@
+import type { TimeOfDayMetric } from './metric';
+
+const HEADERS = [
+  'metric_kind',
+  'metric_minutes',
+  'metric_normalized',
+  'metric_display',
+  'metric_tz_offset'
+] as const;
+
+type HeaderTuple = typeof HEADERS;
+
+type RowTuple = [string, string, string, string, string];
+
+export function metricCsvHeader(): HeaderTuple {
+  return HEADERS;
+}
+
+export function metricCsvRow(metric?: TimeOfDayMetric): RowTuple {
+  if (!metric) {
+    return ['', '', '', '', ''];
+  }
+  return [
+    metric.kind,
+    String(metric.minutesSinceMidnight),
+    String(metric.normalizedMinutes),
+    metric.display,
+    String(metric.tzOffsetMin)
+  ];
+}

--- a/src/lib/exportImport.ts
+++ b/src/lib/exportImport.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 import { habits, logs, validate as validateNegative } from './store';
 import { positive, type PositiveHabit, type PositiveHabitLog } from './positive';
+import type { HabitMetricConfig, TimeOfDayMetric } from './metric';
 import type { Habit, Log } from './types';
 
 export interface ExportPayloadV2 {
@@ -26,18 +27,41 @@ export function exportAll(): ExportPayloadV2 {
   };
 }
 
+function isHabitMetricConfig(data: any): data is HabitMetricConfig {
+  if (!data || typeof data !== 'object') return false;
+  if (data.kind !== 'timeOfDay') return false;
+  if (data.wrapHour !== undefined && typeof data.wrapHour !== 'number') return false;
+  if (data.lowerIsBetter !== undefined && typeof data.lowerIsBetter !== 'boolean') return false;
+  return true;
+}
+
+function isTimeOfDayMetric(data: any): data is TimeOfDayMetric {
+  if (!data || typeof data !== 'object') return false;
+  if (data.kind !== 'timeOfDay') return false;
+  if (typeof data.minutesSinceMidnight !== 'number') return false;
+  if (typeof data.normalizedMinutes !== 'number') return false;
+  if (typeof data.display !== 'string') return false;
+  if (typeof data.tzOffsetMin !== 'number') return false;
+  return true;
+}
+
 function validatePositive(data: any): data is { habits: PositiveHabit[]; logs: PositiveHabitLog[] } {
   if (typeof data !== 'object' || data === null) return false;
   if (!Array.isArray(data.habits) || !Array.isArray(data.logs)) return false;
   const habitsOk = data.habits.every(
-    (h: any) => typeof h.id === 'string' && typeof h.name === 'string' && typeof h.createdAt === 'number'
+    (h: any) =>
+      typeof h.id === 'string' &&
+      typeof h.name === 'string' &&
+      typeof h.createdAt === 'number' &&
+      (h.metric === undefined || isHabitMetricConfig(h.metric))
   );
   const logsOk = data.logs.every(
     (l: any) =>
       typeof l.id === 'string' &&
       typeof l.habitId === 'string' &&
       typeof l.ts === 'number' &&
-      typeof l.note === 'string'
+      typeof l.note === 'string' &&
+      (l.metric === undefined || isTimeOfDayMetric(l.metric))
   );
   return habitsOk && logsOk;
 }

--- a/src/lib/metric.ts
+++ b/src/lib/metric.ts
@@ -1,0 +1,84 @@
+export type MetricKind = 'timeOfDay';
+
+export interface HabitMetricConfig {
+  kind: MetricKind;
+  // For bedtime, earlier is better relative to wrapHour
+  wrapHour?: number; // default 18 (6 PM)
+  lowerIsBetter?: boolean; // default true
+}
+
+export interface TimeOfDayMetric {
+  kind: 'timeOfDay';
+  // minutes since midnight local (0..1439) as logged
+  minutesSinceMidnight: number;
+  // normalized minutes since wrapHour (0..1439), used for comparisons
+  normalizedMinutes: number;
+  // pretty display like "11:23 PM"
+  display: string;
+  // local TZ offset (minutes) for reference
+  tzOffsetMin: number;
+}
+
+export function clampWrapHour(value: number | undefined): number | undefined {
+  if (value === undefined || Number.isNaN(value)) return undefined;
+  const v = Math.trunc(value);
+  if (v < 0) return 0;
+  if (v > 23) return 23;
+  return v;
+}
+
+export function minutesSinceMidnight(date: Date): number {
+  return date.getHours() * 60 + date.getMinutes();
+}
+
+export function normalizeByWrap(minutes: number, wrapHour = 18): number {
+  const safeWrap = clampWrapHour(wrapHour) ?? 18;
+  const shiftMinutes = ((safeWrap % 24) + 24) % 24 * 60;
+  const norm = (Math.round(minutes) - shiftMinutes + 1440) % 1440;
+  return (norm + 1440) % 1440;
+}
+
+export function denormalizeByWrap(normalized: number, wrapHour = 18): number {
+  const safeWrap = clampWrapHour(wrapHour) ?? 18;
+  const shiftMinutes = ((safeWrap % 24) + 24) % 24 * 60;
+  const value = (Math.round(normalized) + shiftMinutes) % 1440;
+  return (value + 1440) % 1440;
+}
+
+export function formatTimeHHMM(date: Date): string {
+  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+export function minutesToDisplay(minutes: number): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setMinutes(Math.max(0, Math.round(minutes)));
+  return formatTimeHHMM(d);
+}
+
+export function buildTimeOfDayMetric(date: Date, cfg?: HabitMetricConfig): TimeOfDayMetric {
+  const wrapHour = clampWrapHour(cfg?.wrapHour) ?? 18;
+  const minutes = minutesSinceMidnight(date);
+  const normalizedMinutes = normalizeByWrap(minutes, wrapHour);
+  const tzOffsetMin = -date.getTimezoneOffset();
+  return {
+    kind: 'timeOfDay',
+    minutesSinceMidnight: minutes,
+    normalizedMinutes,
+    display: formatTimeHHMM(date),
+    tzOffsetMin
+  };
+}
+
+export function betterIsLower(cfg?: HabitMetricConfig): boolean {
+  return cfg?.lowerIsBetter ?? true;
+}
+
+export function isBetterTimeOfDay(
+  a: TimeOfDayMetric,
+  b: TimeOfDayMetric,
+  cfg?: HabitMetricConfig
+): boolean {
+  const lower = betterIsLower(cfg);
+  return lower ? a.normalizedMinutes < b.normalizedMinutes : a.normalizedMinutes > b.normalizedMinutes;
+}

--- a/src/lib/positive.ts
+++ b/src/lib/positive.ts
@@ -2,6 +2,8 @@ import { writable, get } from 'svelte/store';
 import { v4 as uuid } from 'uuid';
 import { load, save } from './persist';
 import { browser } from '$app/environment';
+import { clampWrapHour, normalizeByWrap, minutesToDisplay } from './metric';
+import type { HabitMetricConfig, TimeOfDayMetric } from './metric';
 
 export type PositiveHabitId = string;
 
@@ -9,6 +11,7 @@ export interface PositiveHabit {
   id: PositiveHabitId;
   name: string;
   createdAt: number;
+  metric?: HabitMetricConfig;
 }
 
 export interface PositiveHabitLog {
@@ -16,44 +19,140 @@ export interface PositiveHabitLog {
   habitId: PositiveHabitId;
   ts: number;
   note: string;
+  metric?: TimeOfDayMetric;
 }
 
 export interface PositiveState {
   habits: Record<PositiveHabitId, PositiveHabit>;
   logs: Record<string, PositiveHabitLog>;
   habitLogIndex: Record<PositiveHabitId, string[]>;
-  version: 1;
+  version: 2;
 }
 
-const KEY = 'cokemouse.positive.state.v1';
+const KEY = 'cokemouse.positive.state.v2';
+const LEGACY_KEY = 'cokemouse.positive.state.v1';
 
-const emptyState: PositiveState = { habits: {}, logs: {}, habitLogIndex: {}, version: 1 };
+const emptyState: PositiveState = { habits: {}, logs: {}, habitLogIndex: {}, version: 2 };
 
 const store = writable<PositiveState>(emptyState);
 
-if (browser) {
-  load<PositiveState>(KEY).then(d => {
-    if (d && d.version === 1) {
-      store.set({
-        habits: d.habits ?? {},
-        logs: d.logs ?? {},
-        habitLogIndex: d.habitLogIndex ?? {},
-        version: 1
-      });
-    }
-  });
+interface PersistedStateLike {
+  habits?: any;
+  logs?: any;
+  habitLogIndex?: Record<string, string[]>;
+  version?: number;
 }
 
-let t: any;
+const clampMinutes = (value: any): number | undefined => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < 0) return 0;
+  if (rounded > 1439) return 1439;
+  return rounded;
+};
+
+function sanitizeMetricConfig(input: any): HabitMetricConfig | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  if (input.kind !== 'timeOfDay') return undefined;
+  const wrapHour = clampWrapHour(typeof input.wrapHour === 'number' ? input.wrapHour : undefined);
+  const lowerIsBetter =
+    input.lowerIsBetter === undefined ? undefined : Boolean(input.lowerIsBetter);
+  const cfg: HabitMetricConfig = { kind: 'timeOfDay' };
+  if (wrapHour !== undefined) cfg.wrapHour = wrapHour;
+  if (lowerIsBetter !== undefined) cfg.lowerIsBetter = lowerIsBetter;
+  return cfg;
+}
+
+function sanitizeMetric(
+  input: any,
+  cfg?: HabitMetricConfig
+): TimeOfDayMetric | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  if (input.kind !== 'timeOfDay') return undefined;
+  const minutes = clampMinutes(input.minutesSinceMidnight);
+  if (minutes === undefined) return undefined;
+  const wrapHour = cfg?.wrapHour ?? 18;
+  const normalized =
+    typeof input.normalizedMinutes === 'number' && Number.isFinite(input.normalizedMinutes)
+      ? ((Math.round(input.normalizedMinutes) % 1440) + 1440) % 1440
+      : normalizeByWrap(minutes, wrapHour);
+  const display = typeof input.display === 'string' ? input.display : minutesToDisplay(minutes);
+  const tzOffset =
+    typeof input.tzOffsetMin === 'number' && Number.isFinite(input.tzOffsetMin)
+      ? Math.round(input.tzOffsetMin)
+      : 0;
+  return {
+    kind: 'timeOfDay',
+    minutesSinceMidnight: minutes,
+    normalizedMinutes: normalized,
+    display,
+    tzOffsetMin: tzOffset
+  };
+}
+
+function sanitizeHabit(input: any): PositiveHabit | null {
+  if (!input || typeof input !== 'object') return null;
+  const id = typeof input.id === 'string' ? input.id : undefined;
+  const name = typeof input.name === 'string' ? input.name : undefined;
+  const createdAt =
+    typeof input.createdAt === 'number' && Number.isFinite(input.createdAt)
+      ? input.createdAt
+      : Date.now();
+  if (!id || !name) return null;
+  const metric = sanitizeMetricConfig(input.metric);
+  const habit: PositiveHabit = { id, name, createdAt };
+  if (metric) habit.metric = metric;
+  return habit;
+}
+
+function sanitizeLog(input: any, habits: Record<string, PositiveHabit>): PositiveHabitLog | null {
+  if (!input || typeof input !== 'object') return null;
+  const id = typeof input.id === 'string' ? input.id : undefined;
+  const habitId = typeof input.habitId === 'string' ? input.habitId : undefined;
+  if (!id || !habitId || !habits[habitId]) return null;
+  const ts =
+    typeof input.ts === 'number' && Number.isFinite(input.ts) ? input.ts : Date.now();
+  const note = typeof input.note === 'string' ? input.note : '';
+  const metric = sanitizeMetric(input.metric, habits[habitId].metric);
+  const log: PositiveHabitLog = { id, habitId, ts, note };
+  if (metric) log.metric = metric;
+  return log;
+}
+
+function collectValues<T>(value: any): T[] {
+  if (Array.isArray(value)) return value as T[];
+  if (value && typeof value === 'object') return Object.values(value) as T[];
+  return [];
+}
+
+function sanitizeState(data: PersistedStateLike | null): PositiveState | null {
+  if (!data || typeof data !== 'object') return null;
+  const habits: Record<string, PositiveHabit> = {};
+  for (const raw of collectValues<PositiveHabit>(data.habits)) {
+    const habit = sanitizeHabit(raw);
+    if (habit) habits[habit.id] = habit;
+  }
+  const logs: Record<string, PositiveHabitLog> = {};
+  for (const raw of collectValues<PositiveHabitLog>(data.logs)) {
+    const log = sanitizeLog(raw, habits);
+    if (log) logs[log.id] = log;
+  }
+  const index = buildIndex(Object.values(logs));
+  return { habits, logs, habitLogIndex: index, version: 2 };
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
 function scheduleSave() {
   if (!browser) return;
-  clearTimeout(t);
-  t = setTimeout(() => save(get(store), KEY), 200);
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => save(get(store), KEY), 200);
 }
 
 function buildIndex(logs: PositiveHabitLog[]): Record<PositiveHabitId, string[]> {
   const idx: Record<PositiveHabitId, string[]> = {};
   logs
+    .slice()
     .sort((a, b) => b.ts - a.ts)
     .forEach(l => {
       idx[l.habitId] = idx[l.habitId] ? [...idx[l.habitId], l.id] : [l.id];
@@ -61,12 +160,32 @@ function buildIndex(logs: PositiveHabitLog[]): Record<PositiveHabitId, string[]>
   return idx;
 }
 
+if (browser) {
+  (async () => {
+    const current = await load<PersistedStateLike>(KEY);
+    const state = sanitizeState(current);
+    if (state) {
+      store.set(state);
+      return;
+    }
+    const legacy = await load<PersistedStateLike>(LEGACY_KEY);
+    const migrated = sanitizeState(legacy);
+    if (migrated) {
+      store.set(migrated);
+      await save(migrated, KEY);
+    }
+  })();
+}
+
 export const positive = {
   subscribe: store.subscribe,
-  add(name: string) {
+  add(name: string, metric?: HabitMetricConfig) {
     const id = uuid();
+    const metricCfg = sanitizeMetricConfig(metric);
     store.update(s => {
-      s.habits[id] = { id, name, createdAt: Date.now() };
+      const habit: PositiveHabit = { id, name, createdAt: Date.now() };
+      if (metricCfg) habit.metric = metricCfg;
+      s.habits[id] = habit;
       s.habitLogIndex[id] = s.habitLogIndex[id] ?? [];
       return s;
     });
@@ -79,14 +198,47 @@ export const positive = {
     });
     scheduleSave();
   },
-  log(habitId: string, note: string) {
+  setMetric(id: string, metric?: HabitMetricConfig) {
+    const metricCfg = sanitizeMetricConfig(metric);
+    store.update(s => {
+      if (!s.habits[id]) return s;
+      if (metricCfg) {
+        s.habits[id].metric = metricCfg;
+      } else {
+        delete s.habits[id].metric;
+      }
+      return s;
+    });
+    scheduleSave();
+  },
+  log(
+    habitId: string,
+    note = '',
+    options?: { metric?: TimeOfDayMetric; ts?: number }
+  ) {
+    const state = get(store);
+    const habit = state.habits[habitId];
+    if (!habit) return;
+    const metric =
+      habit.metric?.kind === 'timeOfDay' && options?.metric?.kind === 'timeOfDay'
+        ? sanitizeMetric(options.metric, habit.metric)
+        : undefined;
     const id = uuid();
-    const entry: PositiveHabitLog = { id, habitId, ts: Date.now(), note };
+    const ts = typeof options?.ts === 'number' && Number.isFinite(options.ts)
+      ? options.ts
+      : Date.now();
+    const entry: PositiveHabitLog = { id, habitId, ts, note };
+    if (metric) entry.metric = metric;
     store.update(s => {
       s.logs[id] = entry;
-      const arr = s.habitLogIndex[habitId] ?? [];
-      arr.unshift(id);
-      s.habitLogIndex[habitId] = arr;
+      const existing = s.habitLogIndex[habitId] ?? [];
+      const ids = [...existing, id].filter(Boolean);
+      ids.sort((a, b) => {
+        const logA = s.logs[a];
+        const logB = s.logs[b];
+        return (logB?.ts ?? 0) - (logA?.ts ?? 0);
+      });
+      s.habitLogIndex[habitId] = ids;
       return s;
     });
     scheduleSave();
@@ -126,15 +278,32 @@ export const positive = {
   getLogs(habitId: string): PositiveHabitLog[] {
     const state = get(store);
     const ids = state.habitLogIndex[habitId] ?? [];
-    return ids.map(i => state.logs[i]);
+    return ids.map(i => state.logs[i]).filter(Boolean);
   },
   replace(data: { habits: PositiveHabit[]; logs: PositiveHabitLog[] }) {
     const habitMap: Record<string, PositiveHabit> = {};
-    data.habits.forEach(h => (habitMap[h.id] = h));
+    data.habits.forEach(h => {
+      const metric = sanitizeMetricConfig(h.metric);
+      const habit: PositiveHabit = { id: h.id, name: h.name, createdAt: h.createdAt };
+      if (metric) habit.metric = metric;
+      habitMap[h.id] = habit;
+    });
     const logMap: Record<string, PositiveHabitLog> = {};
-    data.logs.forEach(l => (logMap[l.id] = l));
-    const index = buildIndex(data.logs);
-    store.set({ habits: habitMap, logs: logMap, habitLogIndex: index, version: 1 });
+    data.logs.forEach(l => {
+      const habit = habitMap[l.habitId];
+      if (!habit) return;
+      const metric = sanitizeMetric(l.metric, habit.metric);
+      const log: PositiveHabitLog = {
+        id: l.id,
+        habitId: l.habitId,
+        ts: l.ts,
+        note: l.note ?? ''
+      };
+      if (metric) log.metric = metric;
+      logMap[l.id] = log;
+    });
+    const index = buildIndex(Object.values(logMap));
+    store.set({ habits: habitMap, logs: logMap, habitLogIndex: index, version: 2 });
     scheduleSave();
   }
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { habits, formatDuration } from '../lib/store';
-import { positive } from '../lib/positive';
+import {
+  positive,
+  type PositiveHabit as PositiveHabitModel,
+  type PositiveHabitLog,
+  type PositiveState
+} from '../lib/positive';
 import { exportAll, importAll } from '../lib/exportImport';
 import type { Habit } from '../lib/types';
 import { browser } from '$app/environment';
@@ -8,6 +13,14 @@ import ConfirmDeleteHabitDialog from '../lib/ConfirmDeleteHabitDialog.svelte';
 import NegativeHabitItem from '../lib/NegativeHabitItem.svelte';
 import PositiveTimeline from '../lib/PositiveTimeline.svelte';
 import { logsToCsv } from '../lib/csv';
+import {
+  buildTimeOfDayMetric,
+  clampWrapHour,
+  denormalizeByWrap,
+  normalizeByWrap,
+  isBetterTimeOfDay,
+  type TimeOfDayMetric
+} from '../lib/metric';
 
 let tab: 'positive' | 'negative' = 'negative';
 if (browser) {
@@ -57,9 +70,17 @@ function resetStreak(id: string) {
 
 // positive vars
 let pName = '';
+let pMetricEnabled = false;
+let pMetricWrapHour = 18;
+let pMetricLowerIsBetter = true;
 let logDialog: HTMLDialogElement;
-let logging: { id: string; name: string } | null = null;
+let logging: PositiveHabitModel | null = null;
+let logMode: 'note' | 'metric-now' | 'metric-manual' = 'note';
+let pendingMetricDate: Date | null = null;
+let manualDate = '';
+let manualTime = '';
 let note = '';
+let logError = '';
 const show: Record<string, boolean> = {};
 
 // delete vars
@@ -69,56 +90,177 @@ let lastFocused: HTMLElement | null = null;
 let toast = '';
 let toastTimer: any;
 
-function addPositive() {
-  if (pName.trim()) {
-    positive.add(pName.trim());
-    pName = '';
-  }
+const pad = (n: number) => String(n).padStart(2, '0');
+const toDateInputValue = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+const toTimeInputValue = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+function parseManual(): Date | null {
+  if (!manualDate || !manualTime) return null;
+  const [y, m, d] = manualDate.split('-').map(Number);
+  const [hh, mm] = manualTime.split(':').map(Number);
+  if ([y, m, d, hh, mm].some(n => Number.isNaN(n))) return null;
+  return new Date(y, (m ?? 1) - 1, d ?? 1, hh ?? 0, mm ?? 0, 0, 0);
 }
 
-function openLog(h: { id: string; name: string }) {
-  logging = h;
+function addPositive() {
+  if (!pName.trim()) return;
+  const metricConfig = pMetricEnabled
+    ? {
+        kind: 'timeOfDay' as const,
+        wrapHour: clampWrapHour(pMetricWrapHour) ?? 18,
+        lowerIsBetter: pMetricLowerIsBetter
+      }
+    : undefined;
+  positive.add(pName.trim(), metricConfig);
+  pName = '';
+  pMetricEnabled = false;
+  pMetricWrapHour = 18;
+  pMetricLowerIsBetter = true;
+}
+
+function openLogNote(habit: PositiveHabitModel) {
+  logging = habit;
+  logMode = 'note';
+  pendingMetricDate = null;
+  manualDate = '';
+  manualTime = '';
+  note = '';
+  logError = '';
+  logDialog.showModal();
+}
+
+function openLogNow(habit: PositiveHabitModel) {
+  logging = habit;
+  logMode = 'metric-now';
+  pendingMetricDate = new Date();
+  manualDate = toDateInputValue(pendingMetricDate);
+  manualTime = toTimeInputValue(pendingMetricDate);
+  note = '';
+  logError = '';
+  logDialog.showModal();
+}
+
+function openLogTime(habit: PositiveHabitModel) {
+  logging = habit;
+  logMode = 'metric-manual';
+  const base = new Date();
+  manualDate = toDateInputValue(base);
+  manualTime = toTimeInputValue(base);
+  pendingMetricDate = null;
+  note = '';
+  logError = '';
   logDialog.showModal();
 }
 
 function saveLog() {
-  if (logging) positive.log(logging.id, note.trim());
+  if (!logging) return;
+  const text = note.trim();
+  if (logMode === 'metric-now' && logging.metric?.kind === 'timeOfDay') {
+    const date = pendingMetricDate ?? new Date();
+    const metric = buildTimeOfDayMetric(date, logging.metric);
+    positive.log(logging.id, text, { metric, ts: date.getTime() });
+  } else if (logMode === 'metric-manual' && logging.metric?.kind === 'timeOfDay') {
+    const manual = parseManual();
+    if (!manual) {
+      logError = 'Choose a valid date and time.';
+      return;
+    }
+    const metric = buildTimeOfDayMetric(manual, logging.metric);
+    positive.log(logging.id, text, { metric, ts: manual.getTime() });
+  } else {
+    positive.log(logging.id, text);
+  }
   note = '';
+  logError = '';
+  pendingMetricDate = null;
+  manualDate = '';
+  manualTime = '';
+  logMode = 'note';
   logDialog.close();
   logging = null;
 }
 
 function cancelLog() {
   note = '';
+  logError = '';
+  pendingMetricDate = null;
+  manualDate = '';
+  manualTime = '';
   logDialog.close();
   logging = null;
+  logMode = 'note';
 }
 
 function toggleTimeline(id: string) {
   show[id] = !show[id];
 }
 
-function exportPositiveCsv(habit: { id: string; name: string }) {
+function exportPositiveCsv(habit: PositiveHabitModel) {
   const logs = positive.getLogs(habit.id).map(l => ({
     id: l.id,
     habitId: l.habitId,
     ts: l.ts,
-    note: l.note
+    note: l.note,
+    metric: l.metric
   }));
   const csv = logsToCsv(logs);
   const blob = new Blob([csv], { type: 'text/csv' });
   const url = URL.createObjectURL(blob);
   const slug = habit.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
   const d = new Date();
-  const pad = (n: number) => String(n).padStart(2, '0');
-  const fname = `cokemouse-positive-${slug}_${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(
+  const pad2 = (n: number) => String(n).padStart(2, '0');
+  const fname = `cokemouse-positive-${slug}_${d.getFullYear()}${pad2(d.getMonth() + 1)}${pad2(
     d.getDate()
-  )}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}.csv`;
+  )}-${pad2(d.getHours())}${pad2(d.getMinutes())}${pad2(d.getSeconds())}.csv`;
   const a = document.createElement('a');
   a.href = url;
   a.download = fname;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function toggleHabitMetric(habit: PositiveHabitModel, enabled: boolean) {
+  if (enabled) {
+    positive.setMetric(habit.id, {
+      kind: 'timeOfDay',
+      wrapHour: habit.metric?.wrapHour ?? 18,
+      lowerIsBetter: habit.metric?.lowerIsBetter ?? true
+    });
+  } else {
+    positive.setMetric(habit.id, undefined);
+  }
+}
+
+function updateHabitWrap(habit: PositiveHabitModel, value: number) {
+  const safe = clampWrapHour(Number.isFinite(value) ? value : undefined) ?? 18;
+  positive.setMetric(habit.id, {
+    kind: 'timeOfDay',
+    wrapHour: safe,
+    lowerIsBetter: habit.metric?.lowerIsBetter ?? true
+  });
+}
+
+function updateHabitDirection(habit: PositiveHabitModel, lower: boolean) {
+  positive.setMetric(habit.id, {
+    kind: 'timeOfDay',
+    wrapHour: habit.metric?.wrapHour ?? 18,
+    lowerIsBetter: lower
+  });
+}
+
+function handleMetricToggle(event: Event, habit: PositiveHabitModel) {
+  const input = event.currentTarget as HTMLInputElement;
+  toggleHabitMetric(habit, input.checked);
+}
+
+function handleWrapChange(event: Event, habit: PositiveHabitModel) {
+  const input = event.currentTarget as HTMLInputElement;
+  updateHabitWrap(habit, input.valueAsNumber);
+}
+
+function handleDirectionChange(event: Event, habit: PositiveHabitModel) {
+  const input = event.currentTarget as HTMLInputElement;
+  updateHabitDirection(habit, input.checked);
 }
 
 function openDelete(type: 'positive' | 'negative', id: string, name: string) {
@@ -177,6 +319,66 @@ function importJson(event: Event) {
   reader.readAsText(file);
   input.value = '';
 }
+
+interface MetricSummary {
+  last?: TimeOfDayMetric;
+  best7d?: TimeOfDayMetric;
+  target?: TimeOfDayMetric;
+}
+
+$: positiveState = $positive as PositiveState;
+$: metricSummaries = buildMetricSummaries(positiveState);
+$: manualPreview =
+  logging?.metric?.kind === 'timeOfDay' && logMode === 'metric-manual'
+    ? (() => {
+        const parsed = parseManual();
+        return parsed && logging ? buildTimeOfDayMetric(parsed, logging.metric).display : '';
+      })()
+    : '';
+
+function buildMetricSummaries(state: PositiveState): Record<string, MetricSummary> {
+  const result: Record<string, MetricSummary> = {};
+  const now = Date.now();
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+  for (const habit of Object.values(state.habits)) {
+    if (habit.metric?.kind !== 'timeOfDay') continue;
+    const ids = state.habitLogIndex[habit.id] ?? [];
+    const logs = ids
+      .map(id => state.logs[id])
+      .filter(
+        (log): log is PositiveHabitLog & { metric: TimeOfDayMetric } =>
+          Boolean(log && log.metric?.kind === 'timeOfDay')
+      );
+    if (!logs.length) {
+      result[habit.id] = {};
+      continue;
+    }
+    const summary: MetricSummary = {};
+    summary.last = logs[0].metric;
+    const recent = logs.filter(log => log.ts >= sevenDaysAgo);
+    if (recent.length) {
+      let best = recent[0];
+      for (const entry of recent.slice(1)) {
+        if (isBetterTimeOfDay(entry.metric, best.metric, habit.metric)) {
+          best = entry;
+        }
+      }
+      summary.best7d = best.metric;
+    }
+    const wrapHour = habit.metric.wrapHour ?? 18;
+    const minTargetMinutes = ((wrapHour + 23) % 24) * 60;
+    const minTargetNormalized = normalizeByWrap(minTargetMinutes, wrapHour);
+    let targetNormalized = summary.last.normalizedMinutes - 5;
+    if (targetNormalized < minTargetNormalized) targetNormalized = minTargetNormalized;
+    const targetMinutes = denormalizeByWrap(targetNormalized, wrapHour);
+    const targetDate = new Date();
+    targetDate.setHours(0, 0, 0, 0);
+    targetDate.setMinutes(targetMinutes);
+    summary.target = buildTimeOfDayMetric(targetDate, habit.metric);
+    result[habit.id] = summary;
+  }
+  return result;
+}
 </script>
 
 <dialog bind:this={dialog}>
@@ -191,9 +393,29 @@ function importJson(event: Event) {
 
 <dialog bind:this={logDialog} on:close={cancelLog}>
   <form on:submit|preventDefault={saveLog}>
+    {#if logging?.metric?.kind === 'timeOfDay'}
+      {#if logMode === 'metric-now'}
+        <p class="metric-preview">Logging time: <strong>{buildTimeOfDayMetric(pendingMetricDate ?? new Date(), logging.metric).display}</strong></p>
+      {:else if logMode === 'metric-manual'}
+        <div class="metric-manual">
+          <label>Time
+            <input type="time" bind:value={manualTime} required on:input={() => (logError = '')} />
+          </label>
+          <label>Date
+            <input type="date" bind:value={manualDate} required on:input={() => (logError = '')} />
+          </label>
+        </div>
+        {#if manualPreview}
+          <p class="metric-preview">Preview: {manualPreview}</p>
+        {/if}
+      {/if}
+    {/if}
     <label>Note:
       <textarea bind:value={note}></textarea>
     </label>
+    {#if logError}
+      <p class="error">{logError}</p>
+    {/if}
     <menu>
       <button type="submit">Save</button>
       <button type="button" on:click={cancelLog}>Cancel</button>
@@ -224,17 +446,75 @@ function importJson(event: Event) {
 
 {#if tab === 'positive'}
   <div id="positive-panel" role="tabpanel">
-    <form on:submit|preventDefault={addPositive}>
+    <form on:submit|preventDefault={addPositive} class="positive-form">
       <input bind:value={pName} placeholder="New habit" />
+      <label class="metric-toggle">
+        <input type="checkbox" bind:checked={pMetricEnabled} /> Track bedtime (Time of Day)
+      </label>
+      {#if pMetricEnabled}
+        <div class="metric-settings">
+          <label>Wrap hour
+            <input type="number" min="0" max="23" bind:value={pMetricWrapHour} />
+          </label>
+          <label>
+            <input type="checkbox" bind:checked={pMetricLowerIsBetter} /> Earlier is better
+          </label>
+        </div>
+      {/if}
       <button type="submit">Add</button>
     </form>
     {#each Object.values($positive.habits) as habit (habit.id)}
       <div class="habit">
-        <strong>{habit.name}</strong>
-        <button on:click={() => openLog(habit)}>Log</button>
-        <button on:click={() => openDelete('positive', habit.id, habit.name)}>Delete</button>
-        <button on:click={() => exportPositiveCsv(habit)}>Export CSV</button>
-        <button on:click={() => toggleTimeline(habit.id)}>{show[habit.id] ? 'Hide' : 'Show'} timeline</button>
+        <div class="habit-header">
+          <strong>{habit.name}</strong>
+          <div class="habit-actions">
+            {#if habit.metric?.kind === 'timeOfDay'}
+              <button on:click={() => openLogNow(habit)}>Log Now</button>
+              <button on:click={() => openLogTime(habit)}>Log Time…</button>
+            {:else}
+              <button on:click={() => openLogNote(habit)}>Log</button>
+            {/if}
+            <button on:click={() => exportPositiveCsv(habit)}>Export CSV</button>
+            <button on:click={() => openDelete('positive', habit.id, habit.name)}>Delete</button>
+            <button on:click={() => toggleTimeline(habit.id)}>{show[habit.id] ? 'Hide' : 'Show'} timeline</button>
+          </div>
+        </div>
+        <div class="metric-config">
+          <label>
+            <input
+              type="checkbox"
+              checked={habit.metric?.kind === 'timeOfDay'}
+              on:change={event => handleMetricToggle(event, habit)}
+            />
+            Track bedtime metric
+          </label>
+          {#if habit.metric?.kind === 'timeOfDay'}
+            <div class="metric-settings">
+              <label>Wrap hour
+                <input
+                  type="number"
+                  min="0"
+                  max="23"
+                  value={habit.metric?.wrapHour ?? 18}
+                  on:change={event => handleWrapChange(event, habit)}
+                />
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={habit.metric?.lowerIsBetter ?? true}
+                  on:change={event => handleDirectionChange(event, habit)}
+                />
+                Earlier is better
+              </label>
+            </div>
+            <div class="metric-summary">
+              <span>Last: {metricSummaries[habit.id]?.last?.display ?? '—'}</span>
+              <span>Best (7d): {metricSummaries[habit.id]?.best7d?.display ?? '—'}</span>
+              <span>Tonight’s target: {metricSummaries[habit.id]?.target?.display ?? '—'}</span>
+            </div>
+          {/if}
+        </div>
         {#if show[habit.id]}
           <PositiveTimeline habitId={habit.id} />
         {/if}
@@ -263,7 +543,17 @@ function importJson(event: Event) {
 <style>
 form { margin-bottom: 1rem; }
 .controls { margin-bottom: 1rem; }
-.habit { margin-top: 1rem; }
+.habit { margin-top: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #e5e7eb; }
+.habit-header { display: flex; flex-direction: column; gap: 0.5rem; }
+.habit-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.metric-config { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; }
+.metric-settings { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
+.metric-summary { display: flex; gap: 0.75rem; flex-wrap: wrap; font-size: 0.9em; }
+.metric-summary span { background: #f3f4f6; padding: 0.25rem 0.5rem; border-radius: 999px; }
+.metric-toggle { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.5rem; }
+.metric-manual { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.5rem; }
+.metric-preview { margin: 0.25rem 0 0.5rem; font-size: 0.9em; color: #4b5563; }
+.error { color: #b91c1c; margin: 0.5rem 0; }
 .tabs { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
 [role="tab"][aria-selected="true"] { font-weight: bold; }
 .toast {

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -10,7 +10,8 @@ describe('csv utilities', () => {
     ]);
     Date.prototype.toLocaleString = orig;
     expect(csv).toBe(
-      'log_id,habit_id,epoch_ms,iso_utc,local_iso,note\r\n1,h,0,1970-01-01T00:00:00.000Z,LOCAL,"a,""b""\nline"\r\n'
+      'log_id,habit_id,epoch_ms,iso_utc,local_iso,note,metric_kind,metric_minutes,metric_normalized,metric_display,metric_tz_offset\r\n' +
+        '1,h,0,1970-01-01T00:00:00.000Z,LOCAL,"a,""b""\nline",,,,,\r\n'
     );
   });
 });

--- a/test/metric_timeOfDay.test.ts
+++ b/test/metric_timeOfDay.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from 'vitest';
+import {
+  minutesSinceMidnight,
+  normalizeByWrap,
+  buildTimeOfDayMetric,
+  isBetterTimeOfDay
+} from '../src/lib/metric';
+
+function withLocal(h: number, m: number, y = 2025, mon = 0, d = 1) {
+  return new Date(y, mon, d, h, m, 0, 0);
+}
+
+describe('time-of-day metric helpers', () => {
+  test('minutesSinceMidnight', () => {
+    expect(minutesSinceMidnight(withLocal(0, 0))).toBe(0);
+    expect(minutesSinceMidnight(withLocal(23, 59))).toBe(23 * 60 + 59);
+  });
+
+  test('normalizeByWrap default wrapHour=18', () => {
+    expect(normalizeByWrap(18 * 60, 18)).toBe(0);
+    expect(normalizeByWrap(23 * 60, 18)).toBe(300);
+    expect(normalizeByWrap(2 * 60, 18)).toBe(480);
+  });
+
+  test('buildTimeOfDayMetric + isBetterTimeOfDay (earlier is better)', () => {
+    const a = buildTimeOfDayMetric(withLocal(23, 0));
+    const b = buildTimeOfDayMetric(withLocal(2, 0));
+    expect(isBetterTimeOfDay(a, b)).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR introduces a **Time-of-Day** metric for Positive habits (e.g., *Bedtime*):

- Log Now (captures local HH:MM) and Log Time… (manual HH:MM)
- Normalization with wrap at **18:00** so earlier is better across midnight
- Mini-stats: Last, Best (7d), Tonight’s target (Last - 5m)
- CSV export gains metric columns (kind, minutes, normalized, display, tz)

Negative/Export format unchanged (v2 remains).