### PR TITLE
Add habit pipeline statuses, nudges, and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Coke-mouse is a habit management system that gamifies the balance between positi
 - **Per-habit CSV Export** 📄: Download logs for any habit as a CSV file.
 - **Export/Import** 🔄: Save or load all habit data as JSON for backup or transfer.
 - **Delete Habits** 🗑️: Remove a habit and all its logs via a protected confirmation dialog.
+- **Habit Pipeline & Nudges** 🚦: Track each habit as Queued, Active, Paused, or Archived while lightweight daily/weekly prompts encourage adding and starting habits.
 
 ## Technology
 
@@ -35,6 +36,8 @@ npm run build
 State is saved in IndexedDB using [localforage](https://github.com/localForage/localForage). Use the **Export JSON** button to download your habits and **Import JSON** to restore them from a file.
 
 Deleting a habit is permanent and removes all of its logs. There is no undo, so use the Delete button with care.
+
+The Home view includes a Today bar with quick nudges. Add new ideas straight into the queued pipeline, promote queued habits to active status at the start of the week, and keep an eye on the suggested soft cap of three active habits to stay focused without overload.
 
 Export files are versioned. The current format is `version: 2` and includes both negative and positive sections:
 

--- a/src/lib/NegativeHabitItem.svelte
+++ b/src/lib/NegativeHabitItem.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-  import { logs, formatDuration } from './store';
-  import { logsToCsv } from './csv';
-  import type { Habit } from './types';
+import { logs, formatDuration } from './store';
+import { logsToCsv } from './csv';
+import type { Habit } from './types';
+import { DEFAULT_HABIT_STATUS, HABIT_STATUSES, type HabitStatus } from './habitStatus';
   import NegativeTimeline from './NegativeTimeline.svelte';
 
-  export let habit: Habit;
-  export let logHabit: (id: string) => void;
-  export let openEdit: (h: Habit) => void;
-  export let resetStreak: (id: string) => void;
-  export let openDelete: (id: string, name: string) => void;
+export let habit: Habit;
+export let logHabit: (id: string) => void;
+export let openEdit: (h: Habit) => void;
+export let resetStreak: (id: string) => void;
+export let openDelete: (id: string, name: string) => void;
+export let setStatus: (id: string, status: HabitStatus) => void;
 
   let show = false;
   const panelId = `neg-tl-${habit.id}`;
@@ -51,10 +53,32 @@
     a.click();
     URL.revokeObjectURL(url);
   }
+
+  $: currentStatus = habit.status ?? DEFAULT_HABIT_STATUS;
+
+  function handleStatusChange(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement).value as HabitStatus;
+    setStatus(habit.id, value);
+  }
+
+  function statusLabel(status: HabitStatus): string {
+    return status.charAt(0).toUpperCase() + status.slice(1);
+  }
 </script>
 
 <div class="habit">
-  <strong>{habit.name}</strong>
+  <div class="habit-heading">
+    <strong>{habit.name}</strong>
+    <span class={`status-pill status-${currentStatus}`}>{statusLabel(currentStatus)}</span>
+  </div>
+  <label class="status-select">
+    <span class="sr-only">Status</span>
+    <select value={currentStatus} on:change={handleStatusChange}>
+      {#each HABIT_STATUSES as status}
+        <option value={status}>{statusLabel(status)}</option>
+      {/each}
+    </select>
+  </label>
   {#if last && !show}
     <div>Last: {new Date(last.at).toLocaleString()}</div>
   {/if}
@@ -82,6 +106,63 @@
 </div>
 
 <style>
+  .habit-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .status-pill {
+    font-size: 0.8rem;
+    text-transform: capitalize;
+    background: #e5e7eb;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+  }
+
+  .status-pill.status-queued {
+    background: #ede9fe;
+    color: #5b21b6;
+  }
+
+  .status-pill.status-active {
+    background: #dcfce7;
+    color: #15803d;
+  }
+
+  .status-pill.status-paused {
+    background: #fef3c7;
+    color: #92400e;
+  }
+
+  .status-pill.status-archived {
+    background: #f3f4f6;
+    color: #374151;
+  }
+
+  .status-select {
+    margin: 0.25rem 0 0.5rem;
+    display: inline-block;
+  }
+
+  .status-select select {
+    font-size: 0.85rem;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .timeline {
     max-height: 200px;
     overflow-y: auto;

--- a/src/lib/exportImport.ts
+++ b/src/lib/exportImport.ts
@@ -3,6 +3,7 @@ import { habits, logs, validate as validateNegative } from './store';
 import { positive, type PositiveHabit, type PositiveHabitLog } from './positive';
 import type { HabitMetricConfig, TimeOfDayMetric } from './metric';
 import type { Habit, Log } from './types';
+import { isHabitStatus } from './habitStatus';
 
 export interface ExportPayloadV2 {
   version: 2;
@@ -53,7 +54,8 @@ function validatePositive(data: any): data is { habits: PositiveHabit[]; logs: P
       typeof h.id === 'string' &&
       typeof h.name === 'string' &&
       typeof h.createdAt === 'number' &&
-      (h.metric === undefined || isHabitMetricConfig(h.metric))
+      (h.metric === undefined || isHabitMetricConfig(h.metric)) &&
+      (h.status === undefined || isHabitStatus(h.status))
   );
   const logsOk = data.logs.every(
     (l: any) =>

--- a/src/lib/habitStatus.ts
+++ b/src/lib/habitStatus.ts
@@ -1,0 +1,14 @@
+export type HabitStatus = 'queued' | 'active' | 'paused' | 'archived';
+
+export const DEFAULT_HABIT_STATUS: HabitStatus = 'active';
+
+export const HABIT_STATUSES: HabitStatus[] = ['queued', 'active', 'paused', 'archived'];
+
+export function sanitizeHabitStatus(value: any): HabitStatus {
+  if (typeof value !== 'string') return DEFAULT_HABIT_STATUS;
+  return HABIT_STATUSES.includes(value as HabitStatus) ? (value as HabitStatus) : DEFAULT_HABIT_STATUS;
+}
+
+export function isHabitStatus(value: any): value is HabitStatus {
+  return typeof value === 'string' && HABIT_STATUSES.includes(value as HabitStatus);
+}

--- a/src/lib/nudges.ts
+++ b/src/lib/nudges.ts
@@ -1,0 +1,51 @@
+import type { Habit } from './types';
+import type { PositiveHabit } from './positive';
+import { DEFAULT_HABIT_STATUS, type HabitStatus, sanitizeHabitStatus } from './habitStatus';
+
+interface DailyAddOptions {
+  positiveHabits: PositiveHabit[];
+  negativeHabits: Habit[];
+  now?: Date;
+}
+
+export function shouldShowDailyAddOne({ positiveHabits, negativeHabits, now }: DailyAddOptions): boolean {
+  const current = now ?? new Date();
+  const start = new Date(current);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 1);
+  const startTs = start.getTime();
+  const endTs = end.getTime();
+  const positiveToday = positiveHabits.some(habit => habit.createdAt >= startTs && habit.createdAt < endTs);
+  if (positiveToday) return false;
+  const negativeToday = negativeHabits.some(habit => {
+    const created = new Date(habit.createdAt).getTime();
+    return created >= startTs && created < endTs;
+  });
+  return !negativeToday;
+}
+
+interface WeeklyStartOptions {
+  positiveHabits: PositiveHabit[];
+  negativeHabits: Habit[];
+  weekStarts?: 'sun' | 'mon';
+  now?: Date;
+}
+
+function hasQueued(habits: { status?: HabitStatus }[]): boolean {
+  return habits.some(h => (h.status ? sanitizeHabitStatus(h.status) : DEFAULT_HABIT_STATUS) === 'queued');
+}
+
+export function shouldShowWeeklyStartOne({
+  positiveHabits,
+  negativeHabits,
+  weekStarts = 'sun',
+  now
+}: WeeklyStartOptions): boolean {
+  const current = now ?? new Date();
+  const startIndex = weekStarts === 'mon' ? 1 : 0;
+  if (current.getDay() !== startIndex) return false;
+  const queuedPositive = hasQueued(positiveHabits);
+  const queuedNegative = hasQueued(negativeHabits);
+  return queuedPositive || queuedNegative;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { HabitStatus } from './habitStatus';
+
 export type Habit = {
   id: string;
   name: string;
@@ -5,6 +7,7 @@ export type Habit = {
   goalSeconds: number; // target interval (default 86400)
   streak: number;      // consecutive goal hits
   lastLoggedAt?: string; // cache of last log timestamp (optional)
+  status?: HabitStatus;
 };
 
 export type Log = {

--- a/test/exportImport.test.ts
+++ b/test/exportImport.test.ts
@@ -51,4 +51,36 @@ describe('export/import', () => {
     expect(ok).toBe(false);
     expect(get(positive)).toEqual(before);
   });
+
+  it('export includes habit statuses', () => {
+    habits.add('neg');
+    const neg = get(habits)[0];
+    habits.setHabitStatus(neg.id, 'paused');
+    positive.add('pos');
+    const posId = Object.keys(get(positive).habits)[0];
+    positive.setHabitStatus(posId, 'queued');
+    const data = exportAll();
+    expect(data.negative.habits[0].status).toBe('paused');
+    expect(data.positive.habits[0].status).toBe('queued');
+  });
+
+  it('import defaults missing statuses to active', () => {
+    const payload = {
+      version: 2,
+      exportedAt: 0,
+      negative: {
+        habits: [{ id: 'n', name: 'neg', createdAt: '2023-01-01T00:00:00Z', goalSeconds: 86400, streak: 0 }],
+        logs: []
+      },
+      positive: {
+        habits: [{ id: 'p', name: 'pos', createdAt: 1 }],
+        logs: []
+      }
+    };
+    const ok = importAll(payload);
+    expect(ok).toBe(true);
+    expect(get(habits)[0].status).toBe('active');
+    const posState = get(positive);
+    expect(posState.habits['p'].status).toBe('active');
+  });
 });

--- a/test/negativeStore.test.ts
+++ b/test/negativeStore.test.ts
@@ -12,6 +12,21 @@ describe('negative store log actions', () => {
     vi.useFakeTimers();
   });
 
+  it('quickAddQueuedHabit creates queued habit', () => {
+    habits.quickAddQueuedHabit('queued');
+    const state = get(habits);
+    expect(state[0].status).toBe('queued');
+  });
+
+  it('setHabitStatus persists through replace', () => {
+    habits.add('persist');
+    const id = get(habits)[0].id;
+    habits.setHabitStatus(id, 'paused');
+    const snapshot = { habits: get(habits).map(h => ({ ...h })), logs: get(logs).map(l => ({ ...l })) };
+    habits.replace(snapshot);
+    expect(get(habits)[0].status).toBe('paused');
+  });
+
   it('editLog updates note', () => {
     habits.add('a');
     const habit = get(habits)[0];

--- a/test/nudges.test.ts
+++ b/test/nudges.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowDailyAddOne, shouldShowWeeklyStartOne } from '../src/lib/nudges';
+import type { PositiveHabit } from '../src/lib/positive';
+import type { Habit } from '../src/lib/types';
+
+const makePositive = (overrides: Partial<PositiveHabit> = {}): PositiveHabit => ({
+  id: 'p-' + Math.random(),
+  name: 'pos',
+  createdAt: Date.now(),
+  ...overrides
+});
+
+const makeNegative = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 'n-' + Math.random(),
+  name: 'neg',
+  createdAt: new Date().toISOString(),
+  goalSeconds: 86400,
+  streak: 0,
+  ...overrides
+});
+
+describe('nudges', () => {
+  it('daily add one is true when no habits today', () => {
+    const now = new Date('2023-01-01T12:00:00Z');
+    const result = shouldShowDailyAddOne({ positiveHabits: [], negativeHabits: [], now });
+    expect(result).toBe(true);
+  });
+
+  it('daily add one is false when habit created today', () => {
+    const now = new Date('2023-01-01T12:00:00Z');
+    const habit = makePositive({ createdAt: now.getTime() });
+    const result = shouldShowDailyAddOne({ positiveHabits: [habit], negativeHabits: [], now });
+    expect(result).toBe(false);
+  });
+
+  it('weekly start one true only on week start with queued habits', () => {
+    const monday = new Date('2023-01-02T08:00:00Z');
+    const queued = makePositive({ status: 'queued', createdAt: monday.getTime() });
+    const result = shouldShowWeeklyStartOne({
+      positiveHabits: [queued],
+      negativeHabits: [],
+      weekStarts: 'mon',
+      now: monday
+    });
+    expect(result).toBe(true);
+  });
+
+  it('weekly start one false when not start of week or no queued', () => {
+    const tuesday = new Date('2023-01-03T08:00:00Z');
+    const active = makeNegative({ status: 'active', createdAt: '2023-01-01T00:00:00Z' });
+    const result = shouldShowWeeklyStartOne({
+      positiveHabits: [],
+      negativeHabits: [active],
+      weekStarts: 'mon',
+      now: tuesday
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/test/positiveStore.test.ts
+++ b/test/positiveStore.test.ts
@@ -10,6 +10,25 @@ describe('positive store log actions', () => {
     vi.useFakeTimers();
   });
 
+  it('quickAddQueuedHabit creates queued habit', () => {
+    positive.quickAddQueuedHabit('queued');
+    const state = get(positive);
+    const habit = Object.values(state.habits)[0];
+    expect(habit.status).toBe('queued');
+  });
+
+  it('setHabitStatus persists through replace', () => {
+    positive.add('persist');
+    const id = Object.keys(get(positive).habits)[0];
+    positive.setHabitStatus(id, 'paused');
+    const snapshot = get(positive);
+    positive.replace({
+      habits: Object.values(snapshot.habits).map(h => ({ ...h })),
+      logs: Object.values(snapshot.logs).map(l => ({ ...l }))
+    });
+    expect(get(positive).habits[id].status).toBe('paused');
+  });
+
   it('editLog updates note and persists', () => {
     positive.add('h');
     const id = Object.keys(get(positive).habits)[0];


### PR DESCRIPTION
## Summary
- add shared habit status helpers and status-aware persistence for positive and negative habits
- introduce Today bar nudges with quick queue/start actions plus per-list status filters
- extend export/import schema handling and add tests for pipeline behaviors and nudges

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df71c38634832299357ac532390a63