### PR TITLE
fix: add static PWA manifest link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ npm run build
 - An install hint appears when `beforeinstallprompt` fires. You can remove it later if desired.
 - Service worker set to **autoUpdate**; assets & pages cached for offline use.
 
+### Install tips
+
+- Chrome/Edge: use the omnibox **Install** icon or ⋮ → **Install app**.
+- If not visible, open the app with `?pwa=debug` and confirm `manifest link: yes` and `beforeinstallprompt: ready`.
+
 ### PWA debug overlay
 
 - Open the app with `?pwa=debug` (for example: `/coke-mouse/?pwa=debug`).

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" content="#0b0f17" />
+    <link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
     %sveltekit.head%
     <script id="cm-theme-bootstrap">
       (function () {

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "coke-mouse",
+  "short_name": "coke-mouse",
+  "id": "/coke-mouse/",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#0b0f17",
+  "theme_color": "#0b0f17",
+  "prefer_related_applications": false,
+  "icons": [
+    { "src": "pwa-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "pwa-512x512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "pwa-maskable-192x192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
+    { "src": "pwa-maskable-512x512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a static manifest.webmanifest with icon references for coke-mouse
- inject an explicit <link rel="manifest"> and theme color meta in the app shell
- document install tips in the README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68f33579b33c83228cc28450a9f92bb8